### PR TITLE
To Fix correct AccountID to be shown in Slack

### DIFF
--- a/gd2slack.template
+++ b/gd2slack.template
@@ -162,7 +162,7 @@
     "    const findingDescription = message.detail.description;\n",	
     "    const findingTime = message.detail.updatedAt;\n",
     "    const findingTimeEpoch = Math.floor(new Date(findingTime) / 1000);\n",
-    "    const account =  message.account;\n",
+    "    const account =  message.detail.accountId;\n",
     "    const region =  message.region;\n",
     "    const messageId = message.detail.id;\n",
     "    const lastSeen = `<!date^${findingTimeEpoch}^{date} at {time} | ${findingTime}>`;\n",


### PR DESCRIPTION
This will show the real AccountID instead of the Parent Account AccountID.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
