### PR TITLE
Bump to Node 8.10

### DIFF
--- a/gd2slack.template
+++ b/gd2slack.template
@@ -236,7 +236,7 @@
 			"minSeverityLevel" : {"Ref" : "MinSeverityLevel"}
 		    }
 		},
-                "Runtime": "nodejs4.3",
+                "Runtime": "nodejs8.10",
 		"MemorySize" : "128",
                 "Timeout": "10",
 		"Description" : "Lambda to push GuardDuty findings to slack",


### PR DESCRIPTION
*Description of changes:*

NodeJS 4.3 is deprecated, per https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html "the ability to create new Lambda functions configured to use the Node.js v4.3 runtime will be disabled on July 31, 2018"

Tested and working on Node8.10 via Lambda


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
