### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/gd2slack.template
+++ b/gd2slack.template
@@ -233,7 +233,7 @@
 			"minSeverityLevel" : {"Ref" : "MinSeverityLevel"}
 		    }
 		},
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
 		"MemorySize" : "128",
                 "Timeout": "10",
 		"Description" : "Lambda to push GuardDuty findings to slack",


### PR DESCRIPTION
CloudFormation templates in amazon-guardduty-to-slack have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.