### PR TITLE
Update lambda Runtime to nodejs14.x

### DIFF
--- a/gd2slack.template
+++ b/gd2slack.template
@@ -237,7 +237,7 @@
 			"minSeverityLevel" : {"Ref" : "MinSeverityLevel"}
 		    }
 		},
-                "Runtime": "nodejs12.x",
+                "Runtime": "nodejs14.x",
 		"MemorySize" : "128",
                 "Timeout": "10",
 		"Description" : "Lambda to push GuardDuty findings to slack",


### PR DESCRIPTION
To change  lambda Runtime to nodejs14.x as Node.js 12 reached End-Of-Life (EOL) on April 30, 2022

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
