### PR TITLE
Update gd2slack.template to use node20 instead of 16

### DIFF
--- a/gd2slack.template
+++ b/gd2slack.template
@@ -115,7 +115,6 @@
     " * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.\n",
     " * SPDX-License-Identifier: MIT-0\n",
     " */\n",
-    "const AWS = require('aws-sdk');\n",
     "const url = require('url');\n",
     "const https = require('https');\n",
     "\n",
@@ -237,7 +236,7 @@
 			"minSeverityLevel" : {"Ref" : "MinSeverityLevel"}
 		    }
 		},
-                "Runtime": "nodejs16.x",
+                "Runtime": "nodejs20.x",
 		"MemorySize" : "128",
                 "Timeout": "10",
 		"Description" : "Lambda to push GuardDuty findings to slack",


### PR DESCRIPTION
Remove the require('aws-sdk') as no logner needed and update the runtime to node 20 for the lambda

*Issue #, if available:* https://github.com/aws-samples/amazon-guardduty-to-slack/issues/30

*Description of changes:*
Updating runtime and node code to use nodejs 20 since node16 will be EOL soon by AWS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
